### PR TITLE
Fix footer configuration booleans

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -303,7 +303,7 @@ params:
 
   # Provide footer configuration.
   footer:
-    enable: ture
+    enable: true
     # You can provide your custom footer template using this option.
     # Put your template in "layouts/partials" folder of your repo.
     # template: footer.html
@@ -328,7 +328,7 @@ params:
 
     # Show/hide disclaimer notice in the footer. Default is "false".
     disclaimer:
-      enable: ture
+      enable: true
 
 # Custom Menus, Future develop
 ## https://toha-guides.netlify.app/posts/configuration/site-parameters/#add-custom-menus


### PR DESCRIPTION
## Summary
- fix two `enable` values in `hugo.yaml` that were spelled `ture`

## Testing
- `go test ./...` *(no packages to test)*

------
https://chatgpt.com/codex/tasks/task_e_684139a35b6c8325b56174579753a02d